### PR TITLE
Small tweak to readme and blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@ Install [bower](http://bower.io/) and [jekyll](http://jekyllrb.com/).
     # You need node and npm
     npm install -g bower
     # You need ruby and bundler
-    bundler install
+    bundle install
     # Python dependency to come shortly!
+
+Then get the cities data:
+
+    git submodule init
+    git submodule update
 
 Then run:
 

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -16,7 +16,7 @@
           <a href="https://github.com/stefanw/mapnificent">Find the source on GitHub and help out!</a>
         </p>
         <p>
-          You may be interested to watch a <a href="http://vimeo.com/16362921">video about what Mapnificent can do</a> or read a <a href="http://blog.stefanwehrmeyer.com/post/1448498820/a-mapnificent-world">blog post about how Mapnificent works</a>.
+          You may be interested to watch a <a href="http://vimeo.com/16362921">video about what Mapnificent can do</a> or read a <a href="https://web.archive.org/web/20160305070808/http://blog.stefanwehrmeyer.com/post/1448498820/a-mapnificent-world">blog post about how Mapnificent works</a>.
         </p>
         <p>
           Mapnificent was originally inspired by mySociety's <a href="https://mapumental.com">Mapumental</a>.


### PR DESCRIPTION
Just adds some instructions for doing the git submodule dance and "fixes" a link the blog post about mapnificent by pointing it at the wayback machine version.
