### PR TITLE
Added ignore for vendor folder to repair Jekyll builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _site/
 static/vendor/
+.bundle/
+vendor/

--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,7 @@ collections:
   cities:
     output: true
     permalink: /:path/
+
+# Ignore our `vendor` folder from Bundler
+# https://github.com/jekyll/jekyll/issues/5267#issuecomment-241379902
+exclude: [vendor]


### PR DESCRIPTION
During my setup of the repository, I was running into an issue caused by Bundler and Jekyll:

```
Configuration file: /home/todd/github/mapnificent/_config.yml
            Source: /home/todd/github/mapnificent
       Destination: /home/todd/github/mapnificent/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/gems/jekyll-3.0.3/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

After some searching, it turned out our Jekyll config was loading our Bundler files:

https://github.com/jekyll/jekyll/issues/5267

In this PR:

- Added `exclude` for Bundler files with comment
- Added `.gitignore` for Bundler files

**Result:**

```
Configuration file: /home/todd/github/mapnificent/_config.yml
            Source: /home/todd/github/mapnificent
       Destination: /home/todd/github/mapnificent/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 1.805 seconds.
 Auto-regeneration: enabled for '/home/todd/github/mapnificent'
Configuration file: /home/todd/github/mapnificent/_config.yml
    Server address: http://127.0.0.1:4000//
  Server running... press ctrl-c to stop.
```